### PR TITLE
Feat/add todo items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,29 @@
 
 This is a simple Todo List API built in .NET 8. This project is currently being used for .NET full-stack candidates.
 
+## Features
+
+- Create, read, update and delete todo lists
+- Create, read, update and delete todo items within lists
+- Mark todo items as completed
+
+## API Endpoints
+
+### Todo Lists
+- `GET /api/todolists` - Get all todo lists with their items
+- `GET /api/todolists/{id}` - Get a specific todo list with its items
+- `POST /api/todolists` - Create a new todo list
+- `PUT /api/todolists/{id}` - Update a todo list
+- `DELETE /api/todolists/{id}` - Delete a todo list and its items
+
+### Todo Items
+- `GET /api/todolists/{todoListId}/todos` - Get all items in a todo list
+- `GET /api/todolists/{todoListId}/todos/{itemId}` - Get a specific todo item
+- `POST /api/todolists/{todoListId}/todos` - Create a new todo item
+- `PUT /api/todolists/{todoListId}/todos/{itemId}` - Update a todo item
+- `PATCH /api/todolists/{todoListId}/todos/{itemId}/done` - Mark a todo item as completed
+- `DELETE /api/todolists/{todoListId}/todos/{itemId}` - Delete a todo item
+
 ## Database
 
 The project comes with a devcontainer that provisions a SQL Server database. If you are not going to use the devcontainer, make sure to provision a SQL Server database and

--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -1,0 +1,249 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TodoApi.Controllers;
+using TodoApi.Models;
+
+namespace TodoApi.Tests;
+
+#nullable disable
+public class TodoItemsControllerTests
+{
+    private DbContextOptions<TodoContext> DatabaseContextOptions()
+    {
+        return new DbContextOptionsBuilder<TodoContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+    }
+
+    private void PopulateDatabaseContext(TodoContext context)
+    {
+        // Create a todo list
+        var todoList = new TodoList { Id = 1, Name = "Test List" };
+        context.TodoList.Add(todoList);
+
+        // Add some todo items
+        context.TodoItems.Add(new TodoItem 
+        { 
+            TodoListId = 1, 
+            ItemId = 1, 
+            Description = "Item 1", 
+            Completed = false 
+        });
+        context.TodoItems.Add(new TodoItem 
+        { 
+            TodoListId = 1, 
+            ItemId = 2, 
+            Description = "Item 2", 
+            Completed = true 
+        });
+        context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetTodoItems_WhenCalled_ReturnsTodoItemsList()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.GetTodoItems(1);
+
+            Assert.IsType<OkObjectResult>(result.Result);
+            var items = (result.Result as OkObjectResult).Value as IList<TodoItem>;
+            Assert.Equal(2, items.Count);
+        }
+    }
+
+    [Fact]
+    public async Task GetTodoItems_WhenTodoListDoesNotExist_ReturnsNotFound()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.GetTodoItems(999);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+    }
+
+    [Fact]
+    public async Task GetTodoItem_WhenCalled_ReturnsTodoItem()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.GetTodoItem(1, 1);
+
+            Assert.IsType<OkObjectResult>(result.Result);
+            var item = (result.Result as OkObjectResult).Value as dynamic;
+            Assert.Equal(1, item.TodoListId);
+            Assert.Equal(1, item.ItemId);
+            Assert.Equal("Item 1", item.Description);
+            Assert.False(item.Completed);
+        }
+    }
+
+    [Fact]
+    public async Task GetTodoItem_WhenItemDoesNotExist_ReturnsNotFound()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.GetTodoItem(1, 999);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+    }
+
+    [Fact]
+    public async Task PutTodoItem_WhenCalled_UpdatesTodoItem()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.PutTodoItem(
+                1,
+                1,
+                new Dtos.UpdateTodoItem { Description = "Updated Item", Completed = true }
+            );
+
+            Assert.IsType<OkObjectResult>(result);
+            var updatedItem = await context.TodoItems.FindAsync(1L, 1L);
+            Assert.Equal("Updated Item", updatedItem.Description);
+            Assert.True(updatedItem.Completed);
+        }
+    }
+
+    [Fact]
+    public async Task PutTodoItem_WhenItemDoesNotExist_ReturnsNotFound()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.PutTodoItem(
+                1,
+                999,
+                new Dtos.UpdateTodoItem { Description = "Updated Item", Completed = true }
+            );
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+
+    [Fact]
+    public async Task PostTodoItem_WhenCalled_CreatesTodoItem()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.PostTodoItem(
+                1,
+                new Dtos.CreateTodoItem { Description = "New Item", Completed = false }
+            );
+
+            Assert.IsType<CreatedAtActionResult>(result.Result);
+            Assert.Equal(3, context.TodoItems.Count());
+        }
+    }
+
+    [Fact]
+    public async Task PostTodoItem_WhenTodoListDoesNotExist_ReturnsNotFound()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.PostTodoItem(
+                999,
+                new Dtos.CreateTodoItem { Description = "New Item", Completed = false }
+            );
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteTodoItem_WhenCalled_RemovesTodoItem()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.DeleteTodoItem(1, 1);
+
+            Assert.IsType<NoContentResult>(result);
+            Assert.Equal(1, context.TodoItems.Count());
+        }
+    }
+
+    [Fact]
+    public async Task DeleteTodoItem_WhenItemDoesNotExist_ReturnsNotFound()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.DeleteTodoItem(1, 999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+
+    [Fact]
+    public async Task MarkTodoItemAsDone_WhenCalled_MarksItemAsDone()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.MarkTodoItemAsDone(1, 1);
+
+            Assert.IsType<OkObjectResult>(result);
+            var updatedItem = await context.TodoItems.FindAsync(1L, 1L);
+            Assert.True(updatedItem.Completed);
+        }
+    }
+
+    [Fact]
+    public async Task MarkTodoItemAsDone_WhenItemDoesNotExist_ReturnsNotFound()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var controller = new TodoItemsController(context);
+
+            var result = await controller.MarkTodoItemAsDone(1, 999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+} 

--- a/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
@@ -17,8 +17,35 @@ public class TodoListsControllerTests
 
     private void PopulateDatabaseContext(TodoContext context)
     {
-        context.TodoList.Add(new TodoList { Id = 1, Name = "Task 1" });
-        context.TodoList.Add(new TodoList { Id = 2, Name = "Task 2" });
+        // Create todo lists with items
+        var todoList1 = new TodoList { Id = 1, Name = "Task 1" };
+        var todoList2 = new TodoList { Id = 2, Name = "Task 2" };
+
+        todoList1.Items.Add(new TodoItem 
+        { 
+            TodoListId = 1, 
+            ItemId = 1, 
+            Description = "Item 1", 
+            Completed = false 
+        });
+        todoList1.Items.Add(new TodoItem 
+        { 
+            TodoListId = 1, 
+            ItemId = 2, 
+            Description = "Item 2", 
+            Completed = true 
+        });
+
+        todoList2.Items.Add(new TodoItem 
+        { 
+            TodoListId = 2, 
+            ItemId = 1, 
+            Description = "Item 3", 
+            Completed = false 
+        });
+
+        context.TodoList.Add(todoList1);
+        context.TodoList.Add(todoList2);
         context.SaveChanges();
     }
 
@@ -34,7 +61,15 @@ public class TodoListsControllerTests
             var result = await controller.GetTodoLists();
 
             Assert.IsType<OkObjectResult>(result.Result);
-            Assert.Equal(2, ((result.Result as OkObjectResult).Value as IList<TodoList>).Count);
+            var lists = (result.Result as OkObjectResult).Value as IList<TodoList>;
+            Assert.Equal(2, lists.Count);
+            
+            // Verify items are included
+            var firstList = lists[0];
+            var itemsList = firstList.Items.ToList();
+            Assert.Equal(2, itemsList.Count);
+            Assert.Equal("Item 1", itemsList[0].Description);
+            Assert.Equal("Item 2", itemsList[1].Description);
         }
     }
 
@@ -50,7 +85,12 @@ public class TodoListsControllerTests
             var result = await controller.GetTodoList(1);
 
             Assert.IsType<OkObjectResult>(result.Result);
-            Assert.Equal(1, ((result.Result as OkObjectResult).Value as TodoList).Id);
+            var todoList = (result.Result as OkObjectResult).Value as dynamic;
+            Assert.Equal(1, todoList.Id);
+            Assert.Equal("Task 1", todoList.Name);
+            Assert.Equal(2, todoList.Items.Count);
+            Assert.Equal("Item 1", todoList.Items[0].Description);
+            Assert.Equal("Item 2", todoList.Items[1].Description);
         }
     }
 
@@ -88,6 +128,9 @@ public class TodoListsControllerTests
             );
 
             Assert.IsType<OkObjectResult>(result);
+            var updatedList = (result as OkObjectResult).Value as dynamic;
+            Assert.Equal("Changed Task 2", updatedList.Name);
+            Assert.Equal(1, updatedList.Items.Count);
         }
     }
 
@@ -104,6 +147,8 @@ public class TodoListsControllerTests
 
             Assert.IsType<CreatedAtActionResult>(result.Result);
             Assert.Equal(3, context.TodoList.Count());
+            var newList = await context.TodoList.FindAsync(3L);
+            Assert.Empty(newList.Items);
         }
     }
 
@@ -120,6 +165,26 @@ public class TodoListsControllerTests
 
             Assert.IsType<NoContentResult>(result);
             Assert.Equal(1, context.TodoList.Count());
+            Assert.Equal(2, context.TodoItems.Count()); // Only items from list 1 remain
+        }
+    }
+
+    [Fact]
+    public async Task DeleteTodoList_CascadesToItems_RemovesAllItems()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            // Arrange
+            PopulateDatabaseContext(context);
+            var controller = new TodoListsController(context);
+
+            // Act
+            var result = await controller.DeleteTodoList(1);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+            Assert.Null(await context.TodoList.FindAsync(1L));
+            Assert.Empty(context.TodoItems.Where(i => i.TodoListId == 1));
         }
     }
 }

--- a/TodoApi.Tests/TodoApi.Tests.csproj
+++ b/TodoApi.Tests/TodoApi.Tests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TodoApi.Dtos;
+using TodoApi.Models;
+
+namespace TodoApi.Controllers;
+
+[Route("api/todolists/{todoListId}/todos")]
+[ApiController]
+public class TodoItemsController : ControllerBase
+{
+    private readonly TodoContext _context;
+
+    public TodoItemsController(TodoContext context)
+    {
+        _context = context;
+    }
+
+    // GET: api/todolists/5/todos
+    [HttpGet]
+    public async Task<ActionResult<IList<TodoItem>>> GetTodoItems(long todoListId)
+    {
+        if (!await TodoListExists(todoListId))
+        {
+            return NotFound();
+        }
+
+        var items = await _context.TodoItems
+            .Where(i => i.TodoListId == todoListId)
+            .ToListAsync();
+
+        return Ok(items);
+    }
+
+    // GET: api/todolists/5/todos/3
+    [HttpGet("{itemId}")]
+    public async Task<ActionResult<TodoItem>> GetTodoItem(long todoListId, long itemId)
+    {
+        var todoItem = await _context.TodoItems
+            .FirstOrDefaultAsync(i => i.TodoListId == todoListId && i.ItemId == itemId);
+
+        if (todoItem == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(todoItem);
+    }
+
+    // PUT: api/todolists/5/todos/3
+    [HttpPut("{itemId}")]
+    public async Task<ActionResult> PutTodoItem(long todoListId, long itemId, UpdateTodoItem payload)
+    {
+        var todoItem = await _context.TodoItems
+            .FirstOrDefaultAsync(i => i.TodoListId == todoListId && i.ItemId == itemId);
+
+        if (todoItem == null)
+        {
+            return NotFound();
+        }
+
+        todoItem.Description = payload.Description;
+        todoItem.Completed = payload.Completed;
+
+        await _context.SaveChangesAsync();
+
+        return Ok(todoItem);
+    }
+
+    // PATCH: api/todolists/5/todos/3/done
+    [HttpPatch("{itemId}/done")]
+    public async Task<ActionResult> MarkTodoItemAsDone(long todoListId, long itemId)
+    {
+        var todoItem = await _context.TodoItems
+            .FirstOrDefaultAsync(i => i.TodoListId == todoListId && i.ItemId == itemId);
+
+        if (todoItem == null)
+        {
+            return NotFound();
+        }
+
+        todoItem.Completed = true;
+        await _context.SaveChangesAsync();
+
+        return Ok(todoItem);
+    }
+
+    // POST: api/todolists/5/todos
+    [HttpPost]
+    public async Task<ActionResult<TodoItem>> PostTodoItem(long todoListId, CreateTodoItem payload)
+    {
+        if (!await TodoListExists(todoListId))
+        {
+            return NotFound();
+        }
+
+        // Get the next ItemId for this TodoList
+        var nextItemId = await _context.TodoItems
+            .Where(i => i.TodoListId == todoListId)
+            .MaxAsync(i => (long?)i.ItemId) ?? 0;
+
+        var todoItem = new TodoItem
+        {
+            TodoListId = todoListId,
+            ItemId = nextItemId + 1,
+            Description = payload.Description,
+            Completed = payload.Completed
+        };
+
+        _context.TodoItems.Add(todoItem);
+        await _context.SaveChangesAsync();
+
+        return CreatedAtAction(
+            nameof(GetTodoItem),
+            new { todoListId, itemId = todoItem.ItemId },
+            todoItem
+        );
+    }
+
+    // DELETE: api/todolists/5/todos/3
+    [HttpDelete("{itemId}")]
+    public async Task<ActionResult> DeleteTodoItem(long todoListId, long itemId)
+    {
+        var todoItem = await _context.TodoItems
+            .FirstOrDefaultAsync(i => i.TodoListId == todoListId && i.ItemId == itemId);
+
+        if (todoItem == null)
+        {
+            return NotFound();
+        }
+
+        _context.TodoItems.Remove(todoItem);
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    private async Task<bool> TodoListExists(long id)
+    {
+        return await _context.TodoList.AnyAsync(e => e.Id == id);
+    }
+} 

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -20,14 +20,20 @@ namespace TodoApi.Controllers
         [HttpGet]
         public async Task<ActionResult<IList<TodoList>>> GetTodoLists()
         {
-            return Ok(await _context.TodoList.ToListAsync());
+            var lists = await _context.TodoList
+                .Include(l => l.Items)
+                .ToListAsync();
+
+            return Ok(lists);
         }
 
         // GET: api/todolists/5
         [HttpGet("{id}")]
         public async Task<ActionResult<TodoList>> GetTodoList(long id)
         {
-            var todoList = await _context.TodoList.FindAsync(id);
+            var todoList = await _context.TodoList
+                .Include(l => l.Items)
+                .FirstOrDefaultAsync(l => l.Id == id);
 
             if (todoList == null)
             {

--- a/TodoApi/Data/TodoContext.cs
+++ b/TodoApi/Data/TodoContext.cs
@@ -7,4 +7,17 @@ public class TodoContext : DbContext
         : base(options) { }
 
     public DbSet<TodoList> TodoList { get; set; } = default!;
+    public DbSet<TodoItem> TodoItems { get; set; } = default!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TodoItem>()
+            .HasKey(t => new { t.TodoListId, t.ItemId });
+
+        modelBuilder.Entity<TodoItem>()
+            .HasOne<TodoList>()
+            .WithMany(l => l.Items)
+            .HasForeignKey(t => t.TodoListId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
 }

--- a/TodoApi/Dtos/CreateTodoItem.cs
+++ b/TodoApi/Dtos/CreateTodoItem.cs
@@ -1,0 +1,7 @@
+namespace TodoApi.Dtos;
+
+public class CreateTodoItem
+{
+    public required string Description { get; set; }
+    public bool Completed { get; set; }
+} 

--- a/TodoApi/Dtos/UpdateTodoItem.cs
+++ b/TodoApi/Dtos/UpdateTodoItem.cs
@@ -1,0 +1,7 @@
+namespace TodoApi.Dtos;
+
+public class UpdateTodoItem
+{
+    public required string Description { get; set; }
+    public bool Completed { get; set; }
+} 

--- a/TodoApi/Migrations/20250607001915_CreateTodo.Designer.cs
+++ b/TodoApi/Migrations/20250607001915_CreateTodo.Designer.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace TodoApi.Migrations
 {
     [DbContext(typeof(TodoContext))]
-    partial class TodoContextModelSnapshot : ModelSnapshot
+    [Migration("20250607001915_CreateTodo")]
+    partial class CreateTodo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TodoApi/Migrations/20250607001915_CreateTodo.cs
+++ b/TodoApi/Migrations/20250607001915_CreateTodo.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TodoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateTodo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TodoItems",
+                columns: table => new
+                {
+                    TodoListId = table.Column<long>(type: "bigint", nullable: false),
+                    ItemId = table.Column<long>(type: "bigint", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Completed = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TodoItems", x => new { x.TodoListId, x.ItemId });
+                    table.ForeignKey(
+                        name: "FK_TodoItems_TodoList_TodoListId",
+                        column: x => x.TodoListId,
+                        principalTable: "TodoList",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TodoItems");
+        }
+    }
+}

--- a/TodoApi/Models/TodoItem.cs
+++ b/TodoApi/Models/TodoItem.cs
@@ -1,0 +1,9 @@
+namespace TodoApi.Models;
+
+public class TodoItem
+{
+    public required long TodoListId { get; set; }
+    public required long ItemId { get; set; }
+    public required string Description { get; set; }
+    public bool Completed { get; set; }
+}

--- a/TodoApi/Models/TodoList.cs
+++ b/TodoApi/Models/TodoList.cs
@@ -4,4 +4,5 @@ public class TodoList
 {
     public long Id { get; set; }
     public required string Name { get; set; }
+    public ICollection<TodoItem> Items { get; set; } = [];
 }


### PR DESCRIPTION
# Add TodoItem functionality to Todo API

## Changes

### New TodoItem API
- Added new `TodoItemsController` with CRUD operations for todo items
- Implemented RESTful endpoints for managing todo items within todo lists:
  - `GET /api/todolists/{todoListId}/todos` - List all items in a list
  - `GET /api/todolists/{todoListId}/todos/{itemId}` - Get specific item
  - `POST /api/todolists/{todoListId}/todos` - Create new item
  - `PUT /api/todolists/{todoListId}/todos/{itemId}` - Update item
  - `PATCH /api/todolists/{todoListId}/todos/{itemId}/done` - Mark as completed
  - `DELETE /api/todolists/{todoListId}/todos/{itemId}` - Delete item

### Database Changes
- Added `TodoItem` entity with composite key (TodoListId, ItemId)
- Implemented cascading deletion for todo items when a list is deleted
- Updated `TodoContext` with proper entity relationships and configuration
- Added DTOs for creating and updating todo items

### TodoList API Updates
- Modified `TodoListsController` to include items in responses
- Updated list endpoints to return items along with list data
- Added cascading delete behavior for items when a list is deleted

### Testing
- Added test suite for `TodoItemsController`
- Added test cases for all CRUD operations and edge cases
- Updated existing `TodoListsControllerTests` to include item relationships
- Added test for cascading deletion behavior

## Testing Done
- All unit tests passing
- Verified cascading deletion behavior
- Tested all CRUD operations for both lists and items
- Verified proper error handling for non-existent resources